### PR TITLE
Unpin the XBlock requirement version's upper bound. Bump version.

### DIFF
--- a/edx_user_state_client/tests.py
+++ b/edx_user_state_client/tests.py
@@ -700,11 +700,11 @@ class DictUserStateClient(XBlockUserStateClient):
         increments. If you're using this method, you should be running in an
         async task.
         """
-        for (_, key, scope), entries in self._history.iteritems():
+        for (_, key, one_scope), entries in self._history.iteritems():
             if entries[0].state is None:
                 continue
 
-            if key == block_key and scope == scope:
+            if key == block_key and one_scope == scope:
                 yield entries[0]
 
     def iter_all_for_course(self, course_key, block_type=None, scope=Scope.user_state, batch_size=None):
@@ -713,13 +713,13 @@ class DictUserStateClient(XBlockUserStateClient):
         increments. If you're using this method, you should be running in an
         async task.
         """
-        for (_, key, scope), entries in self._history.iteritems():
+        for (_, key, one_scope), entries in self._history.iteritems():
             if entries[0].state is None:
                 continue
 
             if (
                     key.course_key == course_key and
-                    scope == scope and
+                    one_scope == scope and
                     (block_type is None or key.block_type == block_type)
             ):
 

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,13 @@ from setuptools import setup
 
 setup(
     name="edx_user_state_client",
-    version="1.0.1",
+    version="1.0.2",
     packages=[
         "edx_user_state_client",
     ],
     install_requires=[
         "PyContracts>=1.7.1,<2.0.0",
         "edx-opaque-keys>=0.2.0,<1.0.0",
-        "xblock>=0.4,<1.0.0",
+        "xblock>=0.4,<2.0.0",
     ]
 )


### PR DESCRIPTION
This module is pinning XBlock to version 1.0.0, when the most recent version is 1.1.1. This conflict has caused problems in tox environments, where the old XBlock version gets installed.