### PR TITLE
Remove batch_size parameter from iter_all_for_block and iter_all_for_course

### DIFF
--- a/edx_user_state_client/interface.py
+++ b/edx_user_state_client/interface.py
@@ -242,18 +242,16 @@ class XBlockUserStateClient(object):
         """
         raise NotImplementedError()
 
-    def iter_all_for_block(self, block_key, scope=Scope.user_state, batch_size=None):
+    def iter_all_for_block(self, block_key, scope=Scope.user_state):
         """
-        You get no ordering guarantees. Fetching will happen in batch_size
-        increments. If you're using this method, you should be running in an
+        You get no ordering guarantees. If you're using this method, you should be running in an
         async task.
         """
         raise NotImplementedError()
 
-    def iter_all_for_course(self, course_key, block_type=None, scope=Scope.user_state, batch_size=None):
+    def iter_all_for_course(self, course_key, block_type=None, scope=Scope.user_state):
         """
-        You get no ordering guarantees. Fetching will happen in batch_size
-        increments. If you're using this method, you should be running in an
+        You get no ordering guarantees. If you're using this method, you should be running in an
         async task.
         """
         raise NotImplementedError()

--- a/edx_user_state_client/tests.py
+++ b/edx_user_state_client/tests.py
@@ -694,10 +694,9 @@ class DictUserStateClient(XBlockUserStateClient):
         for entry in self._history[(username, block_key, scope)]:
             yield entry
 
-    def iter_all_for_block(self, block_key, scope=Scope.user_state, batch_size=None):
+    def iter_all_for_block(self, block_key, scope=Scope.user_state):
         """
-        You get no ordering guarantees. Fetching will happen in batch_size
-        increments. If you're using this method, you should be running in an
+        You get no ordering guarantees. If you're using this method, you should be running in an
         async task.
         """
         for (_, key, one_scope), entries in self._history.iteritems():
@@ -707,10 +706,9 @@ class DictUserStateClient(XBlockUserStateClient):
             if key == block_key and one_scope == scope:
                 yield entries[0]
 
-    def iter_all_for_course(self, course_key, block_type=None, scope=Scope.user_state, batch_size=None):
+    def iter_all_for_course(self, course_key, block_type=None, scope=Scope.user_state):
         """
-        You get no ordering guarantees. Fetching will happen in batch_size
-        increments. If you're using this method, you should be running in an
+        You get no ordering guarantees. If you're using this method, you should be running in an
         async task.
         """
         for (_, key, one_scope), entries in self._history.iteritems():

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="edx_user_state_client",
-    version="1.0.3",
+    version="1.0.4",
     packages=[
         "edx_user_state_client",
     ],


### PR DESCRIPTION
Batches will be handled by the implementation, if needed.

This PR is required by https://github.com/edx/edx-platform/pull/17698 (an implementation in edx-platform), which gives an example of how `batch_size` can be configured as a setting.

Please tag as 1.0.4 after merge.

**Project details**:  This PR is part of the "Improved Problem Response Report" project, funded by Australian National University (ANU) and developed by OpenCraft.                                                                                                                   
