### PR TITLE
Add trove classifiers, 1.1.0 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="edx_user_state_client",
-    version="1.0.4",
+    version="1.1.0",
     packages=[
         "edx_user_state_client",
     ],
@@ -10,5 +10,15 @@ setup(
         "PyContracts>=1.7.1,<2.0.0",
         "edx-opaque-keys>=0.2.0,<1.0.0",
         "xblock>=0.4,<2.0.0",
-    ]
+    ],
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+    ],
 )


### PR DESCRIPTION
Add trove classifiers to reflect the recently added Python 3.6 support, prepare a new release for edx-platform to use.