### PR TITLE
refactor: Remove PyContracts.

### DIFF
--- a/edx_user_state_client/interface.py
+++ b/edx_user_state_client/interface.py
@@ -4,17 +4,8 @@ A baseclass for a generic client for accessing XBlock Scope.user_state field dat
 
 from abc import abstractmethod
 from collections import namedtuple
-from datetime import datetime
 
-from contracts import contract, new_contract, ContractsMeta
-from opaque_keys.edx.keys import UsageKey, DefinitionKey
-from xblock.fields import Scope, ScopeBase
-
-new_contract('UsageKey', UsageKey)
-new_contract('DefinitionKey', DefinitionKey)
-new_contract('basestring', str)
-new_contract('datetime', datetime)
-new_contract('block_key', 'UsageKey|DefinitionKey|str|NoneType')
+from xblock.fields import Scope
 
 
 class XBlockUserState(namedtuple('_XBlockUserState', ['username', 'block_key', 'state', 'updated', 'scope'])):
@@ -46,7 +37,7 @@ class XBlockUserState(namedtuple('_XBlockUserState', ['username', 'block_key', '
         )
 
 
-class XBlockUserStateClient(metaclass=ContractsMeta):
+class XBlockUserStateClient():
     """
     First stab at an interface for accessing XBlock User State. This will have
     use StudentModule as a backing store in the default case.
@@ -86,14 +77,6 @@ class XBlockUserStateClient(metaclass=ContractsMeta):
         """
         pass
 
-    @contract(
-        username="basestring",
-        block_key="block_key",
-        scope=ScopeBase,
-        fields="seq(basestring)|set(basestring)|None",
-        returns=XBlockUserState,
-        modify_docstring=False,
-    )
     def get(self, username, block_key, scope=Scope.user_state, fields=None):
         """
         Retrieve the stored XBlock state for a single xblock usage.
@@ -115,14 +98,6 @@ class XBlockUserStateClient(metaclass=ContractsMeta):
         except StopIteration as exception:
             raise self.DoesNotExist() from exception
 
-    @contract(
-        username="basestring",
-        block_key="block_key",
-        state="dict(basestring: *)",
-        scope=ScopeBase,
-        returns=None,
-        modify_docstring=False,
-    )
     def set(self, username, block_key, state, scope=Scope.user_state):
         """
         Set fields for a particular XBlock.
@@ -135,14 +110,6 @@ class XBlockUserStateClient(metaclass=ContractsMeta):
         """
         self.set_many(username, {block_key: state}, scope)
 
-    @contract(
-        username="basestring",
-        block_key="block_key",
-        scope=ScopeBase,
-        fields="seq(basestring)|set(basestring)|None",
-        returns=None,
-        modify_docstring=False,
-    )
     def delete(self, username, block_key, scope=Scope.user_state, fields=None):
         """
         Delete the stored XBlock state for a single xblock usage.
@@ -155,13 +122,6 @@ class XBlockUserStateClient(metaclass=ContractsMeta):
         """
         return self.delete_many(username, [block_key], scope, fields=fields)
 
-    @contract(
-        username="basestring",
-        block_keys="seq(block_key)|set(block_key)",
-        scope=ScopeBase,
-        fields="seq(basestring)|set(basestring)|None",
-        modify_docstring=False,
-    )
     @abstractmethod
     def get_many(self, username, block_keys, scope=Scope.user_state, fields=None):
         """
@@ -179,13 +139,6 @@ class XBlockUserStateClient(metaclass=ContractsMeta):
         """
         raise NotImplementedError()
 
-    @contract(
-        username="basestring",
-        block_keys_to_state="dict(block_key: dict(basestring: *))",
-        scope=ScopeBase,
-        returns=None,
-        modify_docstring=False,
-    )
     @abstractmethod
     def set_many(self, username, block_keys_to_state, scope=Scope.user_state):
         """
@@ -201,14 +154,6 @@ class XBlockUserStateClient(metaclass=ContractsMeta):
         """
         raise NotImplementedError()
 
-    @contract(
-        username="basestring",
-        block_keys="seq(block_key)|set(block_key)",
-        scope=ScopeBase,
-        fields="seq(basestring)|set(basestring)|None",
-        returns=None,
-        modify_docstring=False,
-    )
     @abstractmethod
     def delete_many(self, username, block_keys, scope=Scope.user_state, fields=None):
         """

--- a/edx_user_state_client/tests.py
+++ b/edx_user_state_client/tests.py
@@ -18,7 +18,6 @@ from datetime import datetime
 from unittest import TestCase
 
 import pytz
-from contracts import contract
 from opaque_keys.edx.locator import BlockUsageLocator, CourseLocator
 from xblock.fields import Scope
 
@@ -40,12 +39,10 @@ class _UserStateClientTestUtils(TestCase):
     client = None
 
     @staticmethod
-    @contract(user=int)
     def _user(user):
         """Return the username for user ``user``."""
         return f"user{user}"
 
-    @contract(block=int)
     def _block(self, block):
         """Return a UsageKey for the block ``block``."""
         course = block // 1000
@@ -56,13 +53,11 @@ class _UserStateClientTestUtils(TestCase):
         )
 
     @staticmethod
-    @contract(block=int)
     def _block_type(block):  # pylint: disable=unused-argument
         """Return the block type for the specified ``block``."""
         return 'block_type'
 
     @staticmethod
-    @contract(course=int)
     def _course(course):
         """Return a CourseKey for the course ``course``"""
         return CourseLocator(
@@ -71,7 +66,6 @@ class _UserStateClientTestUtils(TestCase):
             f'run{course}',
         )
 
-    @contract(user=int, block=int, fields="list(string)|None")
     def get(self, user, block, fields=None):
         """
         Get the state for the specified user and block.
@@ -87,7 +81,6 @@ class _UserStateClientTestUtils(TestCase):
             fields=fields
         )
 
-    @contract(user=int, block=int, state="dict(string:*)")
     def set(self, user, block, state):
         """
         Set the state for the specified user and block.
@@ -103,7 +96,6 @@ class _UserStateClientTestUtils(TestCase):
             scope=self.scope,
         )
 
-    @contract(user=int, block=int, fields="list(string)|None")
     def delete(self, user, block, fields=None):
         """
         Delete the state for the specified user and block.
@@ -119,7 +111,6 @@ class _UserStateClientTestUtils(TestCase):
             fields=fields
         )
 
-    @contract(user=int, blocks="list(int)", fields="list(string)|None")
     def get_many(self, user, blocks, fields=None):
         """
         Get the state for the specified user and blocks.
@@ -135,7 +126,6 @@ class _UserStateClientTestUtils(TestCase):
             fields=fields,
         )
 
-    @contract(user=int, block_to_state="dict(int: dict(string: *))")
     def set_many(self, user, block_to_state):
         """
         Set the state for the specified user and blocks.
@@ -154,7 +144,6 @@ class _UserStateClientTestUtils(TestCase):
             scope=self.scope,
         )
 
-    @contract(user=int, blocks="list(int)", fields="list(string)|None")
     def delete_many(self, user, blocks, fields=None):
         """
         Delete the state for the specified user and blocks.
@@ -170,7 +159,6 @@ class _UserStateClientTestUtils(TestCase):
             fields=fields,
         )
 
-    @contract(user=int, block=int)
     def get_history(self, user, block):
         """
         Return the state history for the specified user and block.
@@ -185,7 +173,6 @@ class _UserStateClientTestUtils(TestCase):
             scope=self.scope,
         )
 
-    @contract(block=int)
     def iter_all_for_block(self, block):
         """
         Yield the state for all users for the specified block.
@@ -199,7 +186,6 @@ class _UserStateClientTestUtils(TestCase):
             scope=self.scope,
         )
 
-    @contract(course=int, block_type="string|None")
     def iter_all_for_course(self, course, block_type=None):
         """
         Yield the state for all users for the specified block.

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,5 +2,4 @@
 -c constraints.txt
 
 edx-opaque-keys
-PyContracts
 xblock

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,26 +6,18 @@
 #
 appdirs==1.4.4
     # via fs
-decorator==5.0.9
-    # via pycontracts
 edx-opaque-keys==2.2.1
     # via -r requirements/base.in
 fs==2.4.13
     # via xblock
-future==0.18.2
-    # via pycontracts
 lxml==4.6.3
     # via xblock
 markupsafe==2.0.1
     # via xblock
 pbr==5.6.0
     # via stevedore
-pycontracts==1.8.12
-    # via -r requirements/base.in
 pymongo==3.11.4
     # via edx-opaque-keys
-pyparsing==2.4.7
-    # via pycontracts
 python-dateutil==2.8.1
     # via xblock
 pytz==2021.1
@@ -37,7 +29,6 @@ pyyaml==5.4.1
 six==1.16.0
     # via
     #   fs
-    #   pycontracts
     #   python-dateutil
 stevedore==3.3.0
     # via edx-opaque-keys

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,7 +8,7 @@ alabaster==0.7.12
     # via sphinx
 babel==2.9.1
     # via sphinx
-certifi==2020.12.5
+certifi==2021.5.30
     # via requests
 chardet==4.0.0
     # via requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -26,17 +26,13 @@ click==8.0.1
     #   edx-lint
 code-annotations==1.1.2
     # via edx-lint
-coverage[toml]==5.5
+coverage==5.5
     # via
     #   -r requirements/test.in
     #   pytest-cov
-decorator==5.0.9
-    # via
-    #   -r requirements/base.txt
-    #   pycontracts
-distlib==0.3.1
+distlib==0.3.2
     # via virtualenv
-django==3.2.3
+django==3.2.4
     # via edx-lint
 edx-lint==5.0.0
     # via -r requirements/test.in
@@ -50,10 +46,6 @@ fs==2.4.13
     # via
     #   -r requirements/base.txt
     #   xblock
-future==0.18.2
-    # via
-    #   -r requirements/base.txt
-    #   pycontracts
 iniconfig==1.1.1
     # via pytest
 isort==5.8.0
@@ -91,8 +83,6 @@ py==1.10.0
     #   tox
 pycodestyle==2.7.0
     # via -r requirements/test.in
-pycontracts==1.8.12
-    # via -r requirements/base.txt
 pylint-celery==0.3
     # via edx-lint
 pylint-django==2.4.4
@@ -101,7 +91,7 @@ pylint-plugin-utils==0.6
     # via
     #   pylint-celery
     #   pylint-django
-pylint==2.8.2
+pylint==2.8.3
     # via
     #   edx-lint
     #   pylint-celery
@@ -112,11 +102,8 @@ pymongo==3.11.4
     #   -r requirements/base.txt
     #   edx-opaque-keys
 pyparsing==2.4.7
-    # via
-    #   -r requirements/base.txt
-    #   packaging
-    #   pycontracts
-pytest-cov==2.12.0
+    # via packaging
+pytest-cov==2.12.1
     # via -r requirements/test.in
 pytest==6.2.4
     # via
@@ -144,7 +131,6 @@ six==1.16.0
     #   -r requirements/base.txt
     #   edx-lint
     #   fs
-    #   pycontracts
     #   python-dateutil
     #   tox
     #   virtualenv
@@ -159,9 +145,9 @@ text-unidecode==1.3
     # via python-slugify
 toml==0.10.2
     # via
-    #   coverage
     #   pylint
     #   pytest
+    #   pytest-cov
     #   tox
 tox==3.23.1
     # via -r requirements/test.in

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -6,7 +6,7 @@
 #
 appdirs==1.4.4
     # via virtualenv
-distlib==0.3.1
+distlib==0.3.2
     # via virtualenv
 filelock==3.0.12
     # via

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4
     # via
     #   -r requirements/tox.txt
     #   virtualenv
-certifi==2020.12.5
+certifi==2021.5.30
     # via requests
 chardet==4.0.0
     # via requests
@@ -16,7 +16,7 @@ coverage==5.5
     # via coveralls
 coveralls==3.1.0
     # via -r requirements/travis.in
-distlib==0.3.1
+distlib==0.3.2
     # via
     #   -r requirements/tox.txt
     #   virtualenv

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def is_requirement(line):
 
 setup(
     name="edx_user_state_client",
-    version="1.3.1",
+    version="1.3.2",
     packages=[
         "edx_user_state_client",
     ],


### PR DESCRIPTION
Usage of PyContracts has been deprecated due to lack of use.
This removes the code that uses it and bumps the version number up.

https://openedx.atlassian.net/browse/DEPR-147